### PR TITLE
Prevent pushing to rubygems.org

### DIFF
--- a/partitioned.gemspec
+++ b/partitioned.gemspec
@@ -25,4 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', '~> 4.2.10'
   s.add_development_dependency 'rails', '~> 4.2.10'
   s.add_development_dependency 'rspec-rails'
+
+  # Disallow pushing to rubygems.org
+  s.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/jobseekerltd'
 end


### PR DESCRIPTION
## What does this PR do?

Prevent pushing this to rubygems.org.

Also, I pre-emptively set it to [GitHub's private registry](https://help.github.com/en/github/managing-packages-with-github-packages/configuring-rubygems-for-use-with-github-packages#publishing-a-package) in case we want to push it there.

~~The CI script was also updated to simulate building the gem in CI. This should catch any gemspec errors, if there are any.~~ This repo has no CI scripts.